### PR TITLE
Update to support paginated responses from popit-api

### DIFF
--- a/popit/tests/fixtures/too_many_people.js
+++ b/popit/tests/fixtures/too_many_people.js
@@ -1,0 +1,14 @@
+// See https://github.com/powmedia/pow-mongodb-fixtures for the format used in
+// this file
+
+exports.persons = (function() {
+    var i, result = {};
+    for (i = 0; i < 65; ++i) {
+        result[i] = {
+            _id: "generated-person-" + i,
+            name: "Generated Person " + i
+
+        };
+    }
+    return result;
+}());

--- a/popit/tests/test_popit_instance.py
+++ b/popit/tests/test_popit_instance.py
@@ -72,3 +72,14 @@ class ApiInstanceTest(TestCase):
         person = Person.objects.get(name='Joe Bloggs')
         self.assertTrue(person)
         
+    def test_pagination(self):
+
+        # create the instance, delete contents and load test fixture
+        instance_helpers.delete_api_database()
+        instance_helpers.load_test_data('too_many_people')
+        instance = ApiInstance.objects.create(url=instance_helpers.get_api_url())
+        instance.fetch_all_from_api()
+
+        people_fetched = Person.objects.all()
+
+        self.assertEqual(people_fetched.count(), 65)


### PR DESCRIPTION
Versions 0.0.14 and later of popit-api return collections paginated
by default; this commit updates popit-django so that it will fetch all
of the results whether the results are paginated (version >= 0.0.14)
or not (version < 0.0.14).  Previously, only the first page of results
would be fetched.

Fixes #21 

(This pull request also includes an unrelated small fix.)
